### PR TITLE
chore: add boilerplate OTP application supervisor

### DIFF
--- a/lib/ex_integrate/application.ex
+++ b/lib/ex_integrate/application.ex
@@ -1,0 +1,20 @@
+defmodule ExIntegrate.Application do
+  # See https://hexdocs.pm/elixir/Application.html
+  # for more information on OTP Applications
+  @moduledoc false
+
+  use Application
+
+  @impl true
+  def start(_type, _args) do
+    children = [
+      # Starts a worker by calling: ExIntegrate.Worker.start_link(arg)
+      # {ExIntegrate.Worker, arg}
+    ]
+
+    # See https://hexdocs.pm/elixir/Supervisor.html
+    # for other strategies and supported options
+    opts = [strategy: :one_for_one, name: ExIntegrate.Supervisor]
+    Supervisor.start_link(children, opts)
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -14,7 +14,8 @@ defmodule ExIntegrate.MixProject do
   # Run "mix help compile.app" to learn about applications.
   def application do
     [
-      extra_applications: [:logger]
+      extra_applications: [:logger],
+      mod: {ExIntegrate.Application, []}
     ]
   end
 


### PR DESCRIPTION
To prepare the OTP hierarchy, this adds the default OTP application supervisor generated when running `mix new --sup`.