### PR TITLE
feat: trigger an ExIntegrate build using `mix ei`

### DIFF
--- a/lib/mix/tasks/ei.ex
+++ b/lib/mix/tasks/ei.ex
@@ -1,0 +1,21 @@
+defmodule Mix.Tasks.Ei do
+  @moduledoc """
+  Runs an ExIntegrate build using the provided config file, or `ei.json` by default.
+  """
+
+  use Mix.Task
+
+  @default_config_path "ei.json"
+
+  @impl Mix.Task
+  def run(args) do
+    {parsed, _args, _opts} = parse_opts(args)
+    ei_config_file = Keyword.get(parsed, :config, @default_config_path)
+
+    ExIntegrate.run_steps(ei_config_file)
+  end
+
+  defp parse_opts(opts) do
+    OptionParser.parse(opts, switches: [config: :string])
+  end
+end

--- a/test/mix/tasks/ei_test.exs
+++ b/test/mix/tasks/ei_test.exs
@@ -1,0 +1,11 @@
+defmodule Mix.Tasks.EiTest do
+  use ExUnit.Case, async: true
+
+  alias Mix.Tasks.Ei, as: EiTask
+
+  @ei_config_path "test/fixtures/ei.test.json"
+
+  test "runs an ExIntegrate build using the config file" do
+    assert EiTask.run(["--config", @ei_config_path]) == ExIntegrate.run_steps(@ei_config_path)
+  end
+end


### PR DESCRIPTION
Trigger an ExIntegrate build using `mix ei`. Optionally specify a config file using `mix ei --config path_to_config`.

This is primarily for convenience during ExIntegrate development…may or may not be useful for users.