### PR TITLE
Manage the pipeline lifecycle in a GenServer

### DIFF
--- a/lib/ex_integrate.ex
+++ b/lib/ex_integrate.ex
@@ -4,11 +4,12 @@ defmodule ExIntegrate do
   """
 
   alias ExIntegrate.Boundary.PipelineRunner
+  alias ExIntegrate.Boundary.ConfigParser
   alias ExIntegrate.Core.Run
 
   @spec run_pipelines_from_file(filename :: binary) :: {:ok, Run.t()} | {:error, Run.t()}
   def run_pipelines_from_file(filename) do
-    params = import_json(filename)
+    params = ConfigParser.import_json(filename)
     run_pipelines(params)
   end
 
@@ -26,11 +27,5 @@ defmodule ExIntegrate do
     else
       {:ok, %{run | pipelines: completed_pipelines}}
     end
-  end
-
-  defp import_json(filename) do
-    filename
-    |> File.read!()
-    |> Jason.decode!()
   end
 end

--- a/lib/ex_integrate/application.ex
+++ b/lib/ex_integrate/application.ex
@@ -10,6 +10,7 @@ defmodule ExIntegrate.Application do
     children = [
       # Starts a worker by calling: ExIntegrate.Worker.start_link(arg)
       # {ExIntegrate.Worker, arg}
+      {Task.Supervisor, name: ExIntegrate.TaskSupervisor},
     ]
 
     # See https://hexdocs.pm/elixir/Supervisor.html

--- a/lib/ex_integrate/config_parser.ex
+++ b/lib/ex_integrate/config_parser.ex
@@ -1,0 +1,7 @@
+defmodule ExIntegrate.Boundary.ConfigParser do
+  def import_json(filename) when is_binary(filename) do
+    filename
+    |> File.read!()
+    |> Jason.decode!()
+  end
+end

--- a/lib/ex_integrate/pipeline.ex
+++ b/lib/ex_integrate/pipeline.ex
@@ -13,10 +13,8 @@ defmodule ExIntegrate.Core.Pipeline do
           completed_steps: [Step.t()]
         }
 
-  def new(attrs) do
-    steps = Enum.map(attrs["steps"], &Step.new/1)
-    struct!(__MODULE__, name: attrs["name"], steps: steps)
-  end
+  def new(fields),
+    do: struct!(__MODULE__, fields)
 
   def complete_step(%__MODULE__{} = pipeline, %Step{} = step),
     do: %{pipeline | completed_steps: [step] ++ pipeline.completed_steps}

--- a/lib/ex_integrate/pipeline.ex
+++ b/lib/ex_integrate/pipeline.ex
@@ -33,9 +33,8 @@ defmodule ExIntegrate.Core.Pipeline do
     do: Enum.any?(pipeline.steps, &Step.failed?/1)
 
   @spec complete?(t) :: boolean
-  def complete?(%__MODULE__{} = pipeline) do
-    Zipper.end?(pipeline.steps)
-  end
+  def complete?(%__MODULE__{} = pipeline),
+    do: Zipper.end?(pipeline.steps)
 
   @spec steps(t) :: [Step.t()]
   def steps(%__MODULE__{} = pipeline),

--- a/lib/ex_integrate/pipeline.ex
+++ b/lib/ex_integrate/pipeline.ex
@@ -34,8 +34,7 @@ defmodule ExIntegrate.Core.Pipeline do
 
   @spec complete?(t) :: boolean
   def complete?(%__MODULE__{} = pipeline) do
-    Zipper.right_items(pipeline.steps) == [] and
-      Zipper.node(pipeline.steps) == Zipper.rightmost(pipeline.steps)
+    Zipper.end?(pipeline.steps)
   end
 
   @spec steps(t) :: [Step.t()]

--- a/lib/ex_integrate/pipeline.ex
+++ b/lib/ex_integrate/pipeline.ex
@@ -14,25 +14,31 @@ defmodule ExIntegrate.Core.Pipeline do
           completed_steps: [Step.t()]
         }
 
+  @spec new(fields :: keyword | map) :: t
   def new(fields) do
     fields = put_in(fields[:steps], Zipper.zip(fields[:steps]))
     struct!(__MODULE__, fields)
   end
 
+  @spec complete_step(t, Step.t()) :: t
   def complete_step(%__MODULE__{} = pipeline, %Step{} = step),
     do: %{pipeline | completed_steps: [step] ++ pipeline.completed_steps}
 
+  @spec fail(t) :: t
   def fail(%__MODULE__{} = pipeline),
     do: %{pipeline | failed?: true}
 
+  @spec failed?(t) :: boolean
   def failed?(%__MODULE__{} = pipeline),
     do: Enum.any?(pipeline.steps, &Step.failed?/1)
 
+  @spec complete?(t) :: boolean
   def complete?(%__MODULE__{} = pipeline) do
     Zipper.right_items(pipeline.steps) == [] and
       Zipper.node(pipeline.steps) == Zipper.rightmost(pipeline.steps)
   end
 
+  @spec steps(t) :: [Step.t()]
   def steps(%__MODULE__{} = pipeline),
     do: Zipper.to_list(pipeline.steps)
 
@@ -52,6 +58,20 @@ defmodule ExIntegrate.Core.Pipeline do
   def current_step(%__MODULE__{} = pipeline),
     do: Zipper.node(pipeline.steps)
 
+  @spec replace_current_step(t, Step.t()) :: t
+  def replace_current_step(%__MODULE__{} = pipeline, %Step{} = step) do
+    updated_steps = Zipper.put_current(pipeline.steps, step)
+    %{pipeline | steps: updated_steps}
+  end
+
+  @spec get_step_by_name(t, String.t()) :: Step.t()
+  def get_step_by_name(%__MODULE__{} = pipeline, step_name) do
+    pipeline
+    |> steps()
+    |> Enum.find(fn step -> step.name == step_name end)
+  end
+
+  @spec put_step(t, Step.t(), Step.t()) :: t
   def put_step(%__MODULE__{} = pipeline, %Step{} = old_step, %Step{} = new_step) do
     i = pipeline |> steps |> Enum.find_index(fn step -> step.name == old_step.name end)
 
@@ -61,11 +81,13 @@ defmodule ExIntegrate.Core.Pipeline do
   end
 
   @impl Access
+  @spec fetch(t, String.t()) :: {:ok, Step.t()}
   def fetch(%__MODULE__{} = pipeline, step_name) do
     {:ok, get_step_by_name(pipeline, step_name)}
   end
 
   @impl Access
+  @spec get_and_update(t, String.t(), function) :: {Step.t(), t} | no_return
   def get_and_update(%__MODULE__{} = pipeline, step_name, fun) when is_function(fun, 1) do
     current = get_step_by_name(pipeline, step_name)
 
@@ -81,12 +103,7 @@ defmodule ExIntegrate.Core.Pipeline do
     end
   end
 
-  def get_step_by_name(%__MODULE__{} = pipeline, step_name) do
-    pipeline
-    |> steps()
-    |> Enum.find(fn step -> step.name == step_name end)
-  end
-
   @impl Access
+  @spec pop(term, term) :: no_return
   def pop(_pipeline, _step), do: raise("cannot pop steps!")
 end

--- a/lib/ex_integrate/pipeline.ex
+++ b/lib/ex_integrate/pipeline.ex
@@ -14,7 +14,7 @@ defmodule ExIntegrate.Core.Pipeline do
         }
 
   def new(fields) do
-    fields = Map.put(fields, :steps, :queue.from_list(fields[:steps]))
+    fields = put_in(fields[:steps], :queue.from_list(fields[:steps]))
     struct!(__MODULE__, fields)
   end
 

--- a/lib/ex_integrate/pipeline.ex
+++ b/lib/ex_integrate/pipeline.ex
@@ -28,7 +28,13 @@ defmodule ExIntegrate.Core.Pipeline do
   def failed?(%__MODULE__{} = pipeline),
     do: Enum.any?(pipeline.steps, &Step.failed?/1)
 
-  def steps(%__MODULE__{} = pipeline), do: pipeline.steps
+  def complete?(%__MODULE__{} = pipeline) do
+    Zipper.right_items(pipeline.steps) == [] and
+      Zipper.node(pipeline.steps) == Zipper.rightmost(pipeline.steps)
+  end
+
+  def steps(%__MODULE__{} = pipeline),
+    do: Zipper.to_list(pipeline.steps)
 
   @spec pop_step(t()) :: {Step.t(), t()}
   def pop_step(%__MODULE__{} = pipeline) do
@@ -42,7 +48,7 @@ defmodule ExIntegrate.Core.Pipeline do
   def advance(%__MODULE__{} = pipeline),
     do: %{pipeline | steps: Zipper.right(pipeline.steps)}
 
-  @spec current_step(t) :: Step.t()
+  @spec current_step(t) :: Step.t() | nil
   def current_step(%__MODULE__{} = pipeline),
     do: Zipper.node(pipeline.steps)
 

--- a/lib/ex_integrate/pipeline_runner.ex
+++ b/lib/ex_integrate/pipeline_runner.ex
@@ -2,14 +2,18 @@ defmodule ExIntegrate.Boundary.PipelineRunner do
   @moduledoc """
   Responsible for running steps and reporting their results.
   """
+  use GenServer
 
-  alias ExIntegrate.Core.Step
+  @me __MODULE__
+  @task_supervisor ExIntegrate.TaskSupervisor
+
+  alias ExIntegrate.Boundary.StepRunner
   alias ExIntegrate.Core.Pipeline
 
   @spec run_pipeline(Pipeline.t()) :: Pipeline.t()
   def run_pipeline(%Pipeline{} = pipeline) do
     Enum.reduce(pipeline.steps, pipeline, fn step, acc ->
-      case run_step(step) do
+      case StepRunner.run_step(step) do
         {:ok, step} ->
           Pipeline.complete_step(acc, step)
 
@@ -21,20 +25,46 @@ defmodule ExIntegrate.Boundary.PipelineRunner do
     end)
   end
 
-  @spec run_step(Step.t()) :: {:ok, Step.t()} | {:error, Step.t()}
-  def run_step(%Step{} = step) do
-    path = System.find_executable(step.command)
-
-    case do_run_step(step, path) do
-      {:ok, %{status: status_code, out: out, err: err}} ->
-        {:ok, Step.save_results(step, status_code, out, err)}
-
-      {:error, %{status: status_code, out: out, err: err}} ->
-        {:error, Step.save_results(step, status_code, out, err)}
-    end
+  def start_link({%Pipeline{} = state, config}) do
+    GenServer.start_link(__MODULE__, {state, config}, name: @me)
   end
 
-  defp do_run_step(step, path) do
-    Rambo.run(path, step.args, log: true)
+  def start_link(%Pipeline{} = pipeline, opts \\ []) do
+    config = %{log: opts[:log] || true}
+    start_link({pipeline, config})
+  end
+
+  @impl GenServer
+  def init({%Pipeline{} = pipeline, config}) do
+    {:ok, {pipeline, config}, {:continue, {:next_step}}}
+  end
+
+  @impl GenServer
+  def handle_continue({:next_step}, {state, config}) do
+    {next_step, new_state} = Pipeline.pop_step(state)
+
+    Task.Supervisor.async_nolink(@task_supervisor, fn ->
+      StepRunner.run_step(next_step, log: config.log)
+    end)
+
+    {:noreply, {new_state, config}}
+  end
+
+  @impl GenServer
+  def handle_info({_ref, {:ok, step}}, {state, config}) do
+    IO.puts("Step completed! #{inspect(step)}")
+    {:noreply, {state, config}}
+  end
+
+  @impl GenServer
+  def handle_info({_ref, {:error, step}}, {state, config}) do
+    IO.puts("Step errored! #{inspect(step)}")
+    {:stop, :step_failure, {state, config}}
+  end
+
+  @impl GenServer
+  def handle_info({:DOWN, ref, _, _, reason}, {state, config}) do
+    IO.puts("Step task #{inspect(ref)} terminated. Reason: #{inspect(reason)}")
+    {:noreply, {state, config}}
   end
 end

--- a/lib/ex_integrate/pipeline_runner.ex
+++ b/lib/ex_integrate/pipeline_runner.ex
@@ -2,7 +2,7 @@ defmodule ExIntegrate.Boundary.PipelineRunner do
   @moduledoc """
   Responsible for running steps and reporting their results.
   """
-  use GenServer
+  use GenServer, restart: :temporary
   require Logger
 
   @me __MODULE__
@@ -11,17 +11,70 @@ defmodule ExIntegrate.Boundary.PipelineRunner do
   alias ExIntegrate.Boundary.StepRunner
   alias ExIntegrate.Core.Pipeline
 
-  @spec start_link({Pipeline.t(), Access.t()}) :: {:ok, pid} | {:error, term} | :ignore
-  def start_link({%Pipeline{} = state, opts}) do
-    config = %{log: opts[:log] || true}
-    GenServer.start_link(__MODULE__, {state, config}, name: @me)
+  # Client API
+
+  @spec start_link(Access.t()) :: {:ok, pid} | {:error, term} | :ignore
+  def start_link(opts) do
+    name = opts[:name] || @me
+    GenServer.start_link(__MODULE__, opts, name: name)
   end
 
-  def start_link(%Pipeline{} = pipeline, opts \\ []) do
-    start_link({pipeline, opts})
+  # GenServer callbacks
+
+  @impl GenServer
+  def init(opts) do
+    initial_state = Access.fetch!(opts, :pipeline) |> Pipeline.advance()
+
+    log = opts[:log] || true
+    config = %{log: log}
+
+    {:ok, {initial_state, config}, {:continue, {:run_step}}}
   end
 
-  @deprecated "Use PipelineRunner.start_link/1 instead."
+  @impl GenServer
+  def handle_continue({:run_step}, {state, config}) do
+    Task.Supervisor.async_nolink(@task_supervisor, fn ->
+      current_step = Pipeline.current_step(state)
+      Logger.info("Starting step: #{inspect(current_step)}")
+      StepRunner.run_step(current_step, log: config.log)
+    end)
+
+    {:noreply, {state, config}}
+  end
+
+  @impl GenServer
+  def handle_info({ref, {:ok, step}}, {state, config}) do
+    Logger.info("Step completed. #{inspect(step)}")
+    Process.demonitor(ref, [:flush])
+
+    new_state =
+      state
+      |> Pipeline.replace_current_step(step)
+      |> Pipeline.advance()
+
+    if Pipeline.complete?(new_state) do
+      Logger.info("All steps completed successfully. Terminating pipeline #{inspect(new_state)}")
+      {:stop, :normal, {new_state, config}}
+    else
+      {:noreply, {new_state, config}, {:continue, {:run_step}}}
+    end
+  end
+
+  @impl GenServer
+  def handle_info({_ref, {:error, step}}, {state, config}) do
+    Logger.info("Step errored. #{inspect(step)}")
+    {:stop, :step_failure, state}
+  end
+
+  @impl GenServer
+  def handle_info({:DOWN, ref, _, _, reason}, {state, config}) do
+    Logger.info("Step task #{inspect(ref)} terminated unexpectedly. Reason: #{inspect(reason)}")
+    {:stop, :step_failure, state}
+  end
+
+  @deprecated """
+  It runs pipelines using an old, naive, sequential implementation. Use #{__MODULE__}.start_link/1 instead for the recommended concurrent implementation.
+  """
   def run_pipeline(%Pipeline{} = pipeline) do
     Enum.reduce(pipeline.steps, pipeline, fn step, acc ->
       case StepRunner.run_step(step) do
@@ -35,46 +88,4 @@ defmodule ExIntegrate.Boundary.PipelineRunner do
       end
     end)
   end
-
-  @impl GenServer
-  def init({%Pipeline{} = pipeline, config}) do
-    pipeline = Pipeline.advance(pipeline)
-    {:ok, {pipeline, config}, {:continue, {:run_step}}}
-  end
-
-  @impl GenServer
-  def handle_continue({:run_step}, {state, config}) do
-    Task.Supervisor.async_nolink(@task_supervisor, fn ->
-      current_step = Pipeline.current_step(state)
-      StepRunner.run_step(current_step, log: config.log)
-    end)
-
-    {:noreply, {state, config}}
-  end
-
-  @impl GenServer
-  def handle_info({_ref, {:ok, step}}, {state, config}) do
-    Logger.info("Step completed! #{inspect(step)}")
-
-    if Pipeline.complete?(state) do
-      {:stop, :steps_complete, {state, config}}
-    else
-      new_state = Pipeline.advance(state)
-      {:noreply, {new_state, config}, {:continue, {:run_step}}}
-    end
-  end
-
-  @impl GenServer
-  def handle_info({_ref, {:error, step}}, {state, config}) do
-    Logger.info("Step errored! #{inspect(step)}")
-    {:stop, :step_failure, {state, config}}
-  end
-
-  @impl GenServer
-  def handle_info({:DOWN, ref, _, _, reason}, {state, config}) do
-    Logger.info("Step task #{inspect(ref)} terminated. Reason: #{inspect(reason)}")
-    {:noreply, {state, config}}
-  end
 end
-
-

--- a/lib/ex_integrate/run.ex
+++ b/lib/ex_integrate/run.ex
@@ -1,5 +1,6 @@
 defmodule ExIntegrate.Core.Run do
   alias ExIntegrate.Core.Pipeline
+  alias ExIntegrate.Core.Step
 
   @behaviour Access
 
@@ -25,7 +26,16 @@ defmodule ExIntegrate.Core.Run do
     initial_graph = Graph.new(type: :directed) |> Graph.add_vertex(@root_vertex)
 
     Enum.reduce(params["pipelines"], initial_graph, fn pipeline_attrs, graph ->
-      pipeline = Pipeline.new(pipeline_attrs)
+      steps =
+        Enum.map(pipeline_attrs["steps"], fn step_attrs ->
+          %Step{
+            args: step_attrs["args"],
+            command: step_attrs["command"],
+            name: step_attrs["name"]
+          }
+        end)
+
+      pipeline = struct!(Pipeline, name: pipeline_attrs["name"], steps: steps)
 
       case pipeline_attrs["depends_on"] do
         nil ->

--- a/lib/ex_integrate/step.ex
+++ b/lib/ex_integrate/step.ex
@@ -23,19 +23,17 @@ defmodule ExIntegrate.Core.Step do
           status_code: non_neg_integer
         }
 
-  def new(attrs) when is_map(attrs) do
+  def new(attrs) do
     %__MODULE__{
-      args: attrs["args"],
-      command: attrs["command"],
-      name: attrs["name"]
+      args: attrs[:args] || attrs["args"],
+      command: attrs[:command] || attrs["command"],
+      name: attrs[:name] || attrs["name"]
     }
   end
 
-  def save_results(%__MODULE__{} = step, status_code, out, err) do
-    %{step | status_code: status_code, out: out, err: err}
-  end
+  def save_results(%__MODULE__{} = step, status_code, out, err),
+    do: %{step | status_code: status_code, out: out, err: err}
 
-  def failed?(%__MODULE__{} = step) do
-    is_integer(step.status_code) and step.status_code !== 0 
-  end
+  def failed?(%__MODULE__{} = step),
+    do: is_integer(step.status_code) and step.status_code !== 0
 end

--- a/lib/ex_integrate/step.ex
+++ b/lib/ex_integrate/step.ex
@@ -36,6 +36,6 @@ defmodule ExIntegrate.Core.Step do
   end
 
   def failed?(%__MODULE__{} = step) do
-    step.status_code !== 0 and not is_nil(step.status_code)
+    is_integer(step.status_code) and step.status_code !== 0 
   end
 end

--- a/lib/ex_integrate/step_runner.ex
+++ b/lib/ex_integrate/step_runner.ex
@@ -1,0 +1,17 @@
+defmodule ExIntegrate.Boundary.StepRunner do
+  alias ExIntegrate.Core.Step
+
+  @spec run_step(Step.t()) :: {:ok, Step.t()} | {:error, Step.t()}
+  def run_step(%Step{} = step, opts \\ []) do
+    command_path = System.find_executable(step.command)
+    log = opts[:log] || true
+
+    case Rambo.run(command_path, step.args, log: log) do
+      {:ok, results} -> {:ok, save_results(step, results)}
+      {:error, results} -> {:error, save_results(step, results)}
+    end
+  end
+
+  defp save_results(step, %{status: status_code, out: out, err: err}),
+    do: Step.save_results(step, status_code, out, err)
+end

--- a/lib/ex_integrate/zipper.ex
+++ b/lib/ex_integrate/zipper.ex
@@ -15,8 +15,8 @@ defmodule ExIntegrate.Core.Zipper do
     * [ElixirForum post](https://elixirforum.com/t/elixir-needs-a-fifo-type/5701/24)
   """
 
-  @opaque t :: {left :: term, current :: term, right :: term}
-  @opaque t(l, current, r) :: {l, current, r}
+  @opaque t :: {[term], term | nil | :end, [term]}
+  @opaque t(a_list) :: {[], nil, a_list}
 
   defmodule TraversalError do
     defexception [:message]
@@ -28,7 +28,7 @@ defmodule ExIntegrate.Core.Zipper do
     end
   end
 
-  @spec zip(val) :: t([], nil, val) when val: list
+  @spec zip(val) :: t(val) when val: list
   def zip(list) when is_list(list) do
     {[], nil, list}
   end

--- a/lib/ex_integrate/zipper.ex
+++ b/lib/ex_integrate/zipper.ex
@@ -38,8 +38,11 @@ defmodule ExIntegrate.Core.Zipper do
     do: current
 
   @spec right(t) :: t
-  def right({_, _, []} = zipper),
+  def right({_, :end, []} = zipper),
     do: raise(TraversalError, zipper)
+
+  def right({l, current, []}),
+    do: right({l, current, [:end]})
 
   def right({[], nil, [head_r | tail_r]}),
     do: {[], head_r, tail_r}

--- a/lib/ex_integrate/zipper.ex
+++ b/lib/ex_integrate/zipper.ex
@@ -71,4 +71,12 @@ defmodule ExIntegrate.Core.Zipper do
 
   def to_list({l, current, r}),
     do: l ++ [current | r]
+
+  @spec end?(t) :: boolean
+  def end?(zipper) do
+    case zipper do
+      {_, :end, []} -> true
+      _ -> false
+    end
+  end
 end

--- a/lib/ex_integrate/zipper.ex
+++ b/lib/ex_integrate/zipper.ex
@@ -62,4 +62,10 @@ defmodule ExIntegrate.Core.Zipper do
 
   def right_items({_l, _current, r}),
     do: r
+
+  def to_list({[], nil, r}),
+    do: r
+
+  def to_list({l, current, r}),
+    do: l ++ [current | r]
 end

--- a/lib/ex_integrate/zipper.ex
+++ b/lib/ex_integrate/zipper.ex
@@ -41,10 +41,22 @@ defmodule ExIntegrate.Core.Zipper do
   def right({_, _, []} = zipper),
     do: raise(TraversalError, zipper)
 
-  def right({l, old_current, [head_r | tail_r]}),
-    do: {[old_current | l], head_r, tail_r}
+  def right({[], nil, [head_r | tail_r]}),
+    do: {[], head_r, tail_r}
+
+  def right({l, old_current, [head_r | tail_r]}) do
+    new_l = l ++ [old_current]
+    {new_l, head_r, tail_r}
+  end
 
   @spec put_current(t, term) :: t
   def put_current({l, _current_value, r}, new_value),
     do: {l, new_value, r}
+
+  @spec rightmost(t) :: term
+  def rightmost({_l, _current, r}),
+    do: List.last(r)
+
+  def left_items({l, _current, _r}),
+    do: l
 end

--- a/lib/ex_integrate/zipper.ex
+++ b/lib/ex_integrate/zipper.ex
@@ -1,0 +1,50 @@
+defmodule ExIntegrate.Core.Zipper do
+  @moduledoc """
+  A set of functions operating on zippers. For now, zippers are in two
+  dimensions only.
+
+  The internal structure of a zipper should be considered opaque and subject to
+  change. To get or update the current item, traverse the zipper, or perform any
+  other operation on the zipper, use the public functions exposed in this
+  module.
+
+  References:
+    * [Wikipedia](https://en.wikipedia.org/wiki/Zipper_(data_structure))
+    * [Gerard Huet's original paper](https://www.st.cs.uni-saarland.de/edu/seminare/2005/advanced-fp/docs/huet-zipper.pdf)
+    * [Clojure stdlib](https://clojuredocs.org/clojure.zip/zipper)
+    * [ElixirForum post](https://elixirforum.com/t/elixir-needs-a-fifo-type/5701/24)
+  """
+
+  @opaque t :: {left :: term, current :: term, right :: term}
+  @opaque t(l, current, r) :: {l, current, r}
+
+  defmodule TraversalError do
+    defexception [:message]
+
+    @impl Exception
+    def exception(value) do
+      msg = "cannot traverse the zipper in this direction. #{inspect(value)}"
+      %TraversalError{message: msg}
+    end
+  end
+
+  @spec zip(val) :: t([], nil, val) when val: list
+  def zip(list) when is_list(list) do
+    {[], nil, list}
+  end
+
+  @spec node(t) :: term
+  def node({_l, current, _r}),
+    do: current
+
+  @spec right(t) :: t
+  def right({_, _, []} = zipper),
+    do: raise(TraversalError, zipper)
+
+  def right({l, old_current, [head_r | tail_r]}),
+    do: {[old_current | l], head_r, tail_r}
+
+  @spec put_current(t, term) :: t
+  def put_current({l, _current_value, r}, new_value),
+    do: {l, new_value, r}
+end

--- a/lib/ex_integrate/zipper.ex
+++ b/lib/ex_integrate/zipper.ex
@@ -59,4 +59,7 @@ defmodule ExIntegrate.Core.Zipper do
 
   def left_items({l, _current, _r}),
     do: l
+
+  def right_items({_l, _current, r}),
+    do: r
 end

--- a/test/ex_integrate/pipeline_runner_test.exs
+++ b/test/ex_integrate/pipeline_runner_test.exs
@@ -1,24 +1,24 @@
 defmodule ExIntegrate.Boundary.PipelineRunnerTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
 
   alias ExIntegrate.Boundary.PipelineRunner
   alias ExIntegrate.Core.Pipeline
   alias ExIntegrate.Core.Step
 
-  @moduletag capture_log: false
   test "runs a pipeline with two steps" do
     step1 = Step.new(name: "echo", command: "echo", args: ["pass me"])
     step2 = Step.new(name: "echo", command: "echo", args: ["pass me again"])
     pipeline = Pipeline.new(name: "a pipeline", steps: [step1, step2])
     test_process = self()
+    ref = make_ref()
 
     log_func = fn result ->
-      send(test_process, result)
+      send(test_process, {:log, ref, result})
     end
 
-    start_supervised!({PipelineRunner, {pipeline, %{log: log_func}}})
+    start_supervised!({PipelineRunner, [pipeline: pipeline, log: log_func]})
 
-    assert_receive {_io_type, "pass me\n"}
-    assert_receive {_io_type, "pass me again\n"}
+    assert_receive {:log, ^ref, {_io_type, "pass me\n"}}
+    assert_receive {:log, ^ref, {_io_type, "pass me again\n"}}
   end
 end

--- a/test/ex_integrate/pipeline_runner_test.exs
+++ b/test/ex_integrate/pipeline_runner_test.exs
@@ -1,0 +1,21 @@
+defmodule ExIntegrate.Boundary.PipelineRunnerTest do
+  use ExUnit.Case
+  import ExUnit.CaptureIO
+
+  alias ExIntegrate.Boundary.PipelineRunner
+  alias ExIntegrate.Core.Pipeline
+  alias ExIntegrate.Core.Step
+
+  test "runs a pipeline" do
+    step = Step.new(name: "echo", command: "echo", args: ["pass me"])
+    pipeline = Pipeline.new(name: "a pipeline", steps: [step])
+    test_process = self()
+
+    log_func = fn result ->
+      send(test_process, result)
+    end
+
+    server = start_supervised!({PipelineRunner, {pipeline, %{log: log_func}}})
+    assert_receive {:stdout, "pass me\n"}
+  end
+end

--- a/test/ex_integrate/pipeline_runner_test.exs
+++ b/test/ex_integrate/pipeline_runner_test.exs
@@ -1,21 +1,24 @@
 defmodule ExIntegrate.Boundary.PipelineRunnerTest do
   use ExUnit.Case
-  import ExUnit.CaptureIO
 
   alias ExIntegrate.Boundary.PipelineRunner
   alias ExIntegrate.Core.Pipeline
   alias ExIntegrate.Core.Step
 
-  test "runs a pipeline" do
-    step = Step.new(name: "echo", command: "echo", args: ["pass me"])
-    pipeline = Pipeline.new(name: "a pipeline", steps: [step])
+  @moduletag capture_log: false
+  test "runs a pipeline with two steps" do
+    step1 = Step.new(name: "echo", command: "echo", args: ["pass me"])
+    step2 = Step.new(name: "echo", command: "echo", args: ["pass me again"])
+    pipeline = Pipeline.new(name: "a pipeline", steps: [step1, step2])
     test_process = self()
 
     log_func = fn result ->
       send(test_process, result)
     end
 
-    server = start_supervised!({PipelineRunner, {pipeline, %{log: log_func}}})
-    assert_receive {:stdout, "pass me\n"}
+    start_supervised!({PipelineRunner, {pipeline, %{log: log_func}}})
+
+    assert_receive {_io_type, "pass me\n"}
+    assert_receive {_io_type, "pass me again\n"}
   end
 end

--- a/test/ex_integrate/pipeline_test.exs
+++ b/test/ex_integrate/pipeline_test.exs
@@ -4,23 +4,23 @@ defmodule ExIntegrate.PipelineTest do
   alias ExIntegrate.Core.{Pipeline, Step}
 
   test "get a pipeline's step by name" do
-    step = %Step{name: "my step", command: "foo", args: []}
-    pipeline = %Pipeline{name: "my pipeline", steps: [step]}
+    step = Step.new(name: "my step", command: "foo", args: [])
+    pipeline = Pipeline.new(name: "my pipeline", steps: [step])
 
     assert pipeline[step.name] == step
   end
 
   test "update a pipeline's step" do
-    step = %Step{name: "my step", command: "foo", args: []}
-    pipeline = %Pipeline{name: "my pipeline", steps: [step]}
+    step = Step.new(name: "my step", command: "foo", args: [])
+    pipeline = Pipeline.new(name: "my pipeline", steps: [step])
     updated_step = %{step | status_code: 0}
 
     assert Pipeline.put_step(pipeline, step, updated_step)
   end
 
   test "get and update a pipeline's step" do
-    step = %Step{name: "my step", command: "foo", args: []}
-    pipeline = %Pipeline{name: "my pipeline", steps: [step]}
+    step = Step.new(name: "my step", command: "foo", args: [])
+    pipeline = Pipeline.new(name: "my pipeline", steps: [step])
     updated_step = %{step | status_code: 0}
 
     assert Pipeline.get_and_update(pipeline, step.name, fn current_step ->

--- a/test/ex_integrate/pipeline_test.exs
+++ b/test/ex_integrate/pipeline_test.exs
@@ -27,4 +27,12 @@ defmodule ExIntegrate.PipelineTest do
              {current_step, updated_step}
            end)
   end
+
+  test "get the next step in the queue" do
+    step1 = %Step{name: "my step 1", command: "foo", args: []}
+    step2 = %Step{name: "my step 2", command: "foo", args: []}
+    pipeline = Pipeline.new(%{name: "my pipeline", steps: [step1, step2]})
+
+    assert {%Step{}, %Pipeline{}} = Pipeline.pop_step(pipeline)
+  end
 end

--- a/test/ex_integrate/pipeline_test.exs
+++ b/test/ex_integrate/pipeline_test.exs
@@ -36,4 +36,18 @@ defmodule ExIntegrate.PipelineTest do
     pipeline = pipeline |> Pipeline.advance() |> Pipeline.advance()
     assert Pipeline.current_step(pipeline) == step2
   end
+
+  test "replace the current step" do
+    step1 = Step.new(name: "a step #{System.unique_integer()}", command: "foo", args: [])
+    step2 = Step.new(name: "a step #{System.unique_integer()}", command: "foo", args: [])
+    pipeline = Pipeline.new(%{name: "my pipeline", steps: [step1, step2]})
+    updated_step = %{step2 | status_code: Enum.random([0, 1, 2, 3])}
+
+    updated_pipeline =
+      pipeline
+      |> Pipeline.advance()
+      |> Pipeline.replace_current_step(updated_step)
+
+    assert Pipeline.current_step(updated_pipeline) == updated_step
+  end
 end

--- a/test/ex_integrate/pipeline_test.exs
+++ b/test/ex_integrate/pipeline_test.exs
@@ -28,11 +28,12 @@ defmodule ExIntegrate.PipelineTest do
            end)
   end
 
-  test "get the next step in the queue" do
-    step1 = %Step{name: "my step 1", command: "foo", args: []}
-    step2 = %Step{name: "my step 2", command: "foo", args: []}
+  test "advance to the next step" do
+    step1 = Step.new(name: "a step #{System.unique_integer()}", command: "foo", args: [])
+    step2 = Step.new(name: "a step #{System.unique_integer()}", command: "foo", args: [])
     pipeline = Pipeline.new(%{name: "my pipeline", steps: [step1, step2]})
 
-    assert {%Step{}, %Pipeline{}} = Pipeline.pop_step(pipeline)
+    pipeline = pipeline |> Pipeline.advance() |> Pipeline.advance()
+    assert Pipeline.current_step(pipeline) == step2
   end
 end

--- a/test/ex_integrate/zipper_test.exs
+++ b/test/ex_integrate/zipper_test.exs
@@ -58,4 +58,15 @@ defmodule ExIntegrate.Core.ZipperTest do
     zipper = Z.zip(original_list)
     assert Z.to_list(zipper) == original_list
   end
+
+  test "checks if the focus has reached the end" do
+    zipper_at_end =
+      ["something", [[42]]]
+      |> Z.zip()
+      |> Z.right()
+      |> Z.right()
+      |> Z.right()
+
+    assert Z.end?(zipper_at_end)
+  end
 end

--- a/test/ex_integrate/zipper_test.exs
+++ b/test/ex_integrate/zipper_test.exs
@@ -11,8 +11,10 @@ defmodule ExIntegrate.Core.ZipperTest do
   describe "modifying current item" do
     test "on success, modifies the item" do
       zipper = [1, 2, 42] |> Z.zip() |> Z.right()
-      updated_zipper = zipper |> Z.put_current(:bar)
-      assert Z.node(updated_zipper) == :bar
+      new_item = Enum.random([:bar, [[42], "foo"], %{baz: :bat}])
+      updated_zipper = Z.put_current(zipper, new_item)
+
+      assert Z.node(updated_zipper) == new_item
     end
   end
 
@@ -22,11 +24,16 @@ defmodule ExIntegrate.Core.ZipperTest do
       assert Z.node(zipper) == 1
     end
 
-    test "raises when there aren't elements to the right" do
+    test "when at the end, adds an 'end' token" do
+      zipper = [42, :foo, ["bar"]] |> Z.zip() |> Z.right() |> Z.right() |> Z.right() |> Z.right()
+      assert Z.node(zipper) == :end
+    end
+
+    test "raises when trying to move past the 'end' token" do
       zipper = [1] |> Z.zip()
 
       assert_raise Z.TraversalError, fn ->
-        zipper |> Z.right() |> Z.right()
+        zipper |> Z.right() |> Z.right() |> Z.right()
       end
     end
   end

--- a/test/ex_integrate/zipper_test.exs
+++ b/test/ex_integrate/zipper_test.exs
@@ -1,0 +1,33 @@
+defmodule ExIntegrate.Core.ZipperTest do
+  use ExUnit.Case, async: true
+
+  alias ExIntegrate.Core.Zipper, as: Z
+
+  test "initially, current item is nil" do
+    zipper = Z.zip([1, 2, :foo])
+    assert is_nil(Z.node(zipper))
+  end
+
+  describe "modifying current item" do
+    test "on success, modifies the item" do
+      zipper = [1, 2, 42] |> Z.zip() |> Z.right()
+      updated_zipper = zipper |> Z.put_current(:bar)
+      assert Z.node(updated_zipper) == :bar
+    end
+  end
+
+  describe "moving to the right" do
+    test "when there are elements to the right" do
+      zipper = [1, 2] |> Z.zip() |> Z.right()
+      assert Z.node(zipper) == 1
+    end
+
+    test "raises when there aren't elements to the right" do
+      zipper = [1] |> Z.zip()
+
+      assert_raise Z.TraversalError, fn ->
+        zipper |> Z.right() |> Z.right()
+      end
+    end
+  end
+end

--- a/test/ex_integrate/zipper_test.exs
+++ b/test/ex_integrate/zipper_test.exs
@@ -45,4 +45,10 @@ defmodule ExIntegrate.Core.ZipperTest do
     zipper = ["something", [42, :blue], 56] |> Z.zip() |> Z.right() |> Z.right()
     assert Z.right_items(zipper) == [56]
   end
+
+  test "converts to list" do
+    original_list = [1..2, {"something", :foo, []}, {{:bar}}]
+    zipper = Z.zip(original_list)
+    assert Z.to_list(zipper) == original_list
+  end
 end

--- a/test/ex_integrate/zipper_test.exs
+++ b/test/ex_integrate/zipper_test.exs
@@ -17,7 +17,7 @@ defmodule ExIntegrate.Core.ZipperTest do
   end
 
   describe "moving to the right" do
-    test "when there are elements to the right" do
+    test "when there are items to the right, moves to the right" do
       zipper = [1, 2] |> Z.zip() |> Z.right()
       assert Z.node(zipper) == 1
     end
@@ -29,5 +29,15 @@ defmodule ExIntegrate.Core.ZipperTest do
         zipper |> Z.right() |> Z.right()
       end
     end
+  end
+
+  test "gets the rightmost item" do
+    zipper = Z.zip([1, :foo, ["three"]])
+    assert Z.rightmost(zipper) == ["three"]
+  end
+
+  test "gets the items left of the current one" do
+    zipper = [1, :foo, ["three"]] |> Z.zip() |> Z.right() |> Z.right() |> Z.right()
+    assert Z.left_items(zipper) == [1, :foo]
   end
 end

--- a/test/ex_integrate/zipper_test.exs
+++ b/test/ex_integrate/zipper_test.exs
@@ -40,4 +40,9 @@ defmodule ExIntegrate.Core.ZipperTest do
     zipper = [1, :foo, ["three"]] |> Z.zip() |> Z.right() |> Z.right() |> Z.right()
     assert Z.left_items(zipper) == [1, :foo]
   end
+
+  test "gets the items right of the current one" do
+    zipper = ["something", [42, :blue], 56] |> Z.zip() |> Z.right() |> Z.right()
+    assert Z.right_items(zipper) == [56]
+  end
 end

--- a/test/ex_integrate_test.exs
+++ b/test/ex_integrate_test.exs
@@ -66,23 +66,4 @@ defmodule ExIntegrateTest do
       assert {:error, _} = ExIntegrate.run_pipelines(config_params)
     end
   end
-
-  describe "touching a tmp file" do
-    setup :create_tmp_dir
-
-    test "success: creates the file", %{tmp_dir_path: tmp_dir_path} do
-      path = Path.join([tmp_dir_path, "ei_test.txt"])
-      step = Step.new(%{"name" => "create_tmp_file", "command" => "touch", "args" => [path]})
-      assert {:ok, _} = ExIntegrate.Boundary.PipelineRunner.run_step(step)
-      assert {:ok, _} = File.read(path)
-    end
-
-    defp create_tmp_dir(_context) do
-      tmp_dir_path = Path.join([System.tmp_dir!(), "ei_test"])
-      File.mkdir!(tmp_dir_path)
-      on_exit(fn -> File.rm_rf!(tmp_dir_path) end)
-
-      [tmp_dir_path: tmp_dir_path]
-    end
-  end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,1 @@
-ExUnit.start()
+ExUnit.start(capture_log: true)


### PR DESCRIPTION
This provides the first concurrent implementation of a Pipeline Runner, responsible for managing the lifecycle of a single pipeline, modeled as a GenServer that runs each step in sequence and terminates gracefully.

## Tracking step progress with a zipper

Previously, a pipeline's steps were modeled as a list, but that did not allow for tracking which steps had been run and which one is currently running. Neither does a queue.

After some reading, I think a better model for tracking the progression of steps is that of a [zipper](https://en.wikipedia.org/wiki/Zipper_(data_structure)) that can keep track of where the "focus" is at any given time. I implemented it as a simple `ExIntegrate.Core.Zipper` data structure in two dimensions. 

So calling `my_pipeline.steps` returns a zipper that contains all the steps that have run, the step currently in focus, and the steps remaining. Public functions on `ExIntegrate.Core.Pipeline` wrap the bare Zipper operations and expose all the operations needed for managing pipeline state. For instance, advance the pipeline forward to the next step with `Pipeline.advance/1`, or check if all steps have completed with `Pipeline.completed?/1`. Under the hood, it relies on the zipper implementation.

References:
  * Wikipedia [Zipper](https://en.wikipedia.org/wiki/Zipper_(data_structure)) article
  * [Zipper article](https://github.com/doorgan/sourceror/blob/main/notebooks/zippers.livemd) by Doorgan as well as the [source code](https://github.com/doorgan/sourceror/blob/main/lib/sourceror/zipper.ex) for his own zipper implementation (a three-dimensional one for traversing the Elixir AST).
  * [Gérard Huet's original paper](https://www.st.cs.uni-saarland.de/edu/seminare/2005/advanced-fp/docs/huet-zipper.pdf)
  * Zipper module from the [Clojure stdlib](https://clojuredocs.org/clojure.zip/zipper)
  * [ElixirForum discussion](https://elixirforum.com/t/elixir-needs-a-fifo-type/5701/24)

## Lifecycle of a PipelineRunner
1. Spawned using `PipelineRunner.start_link/1`, with a `%Pipeline{}` passed in for the initial state
2. Automatically starts the first step, wrapping it in a call to `ExIntegrate.TaskSupervisor.async_nolink/3`
3. Listen for a message with the step results
  a. On step success, stores the step results and starts the next step.
  b. On step failure, terminates without starting any more steps
    - We may want to customize this behavior
4. On successful completion of all steps, terminates with `:normal` [exit status](https://hexdocs.pm/elixir/Supervisor.html#module-exit-reasons-and-restarts)

Note that when PipelineRunner terminates for any reason (i.e. 3b or 4), it will *not* be restarted by its parent supervisor, owing to its child spec [restart value](https://hexdocs.pm/elixir/Supervisor.html#module-restart-values-restart) of `:temporary`. I believe this is the desired behavior, but please correct me if I am missing something.

## Final thoughts
I haven't covered every edge case here. We'll want to consider at least the following scenarios concerning individual pipeline runs:
- A particular step takes too long and times out
- The PipelineRunner is shut down mid-step by an external process (like a supervisor), or even by application termination or other unforeseen causes

WDYT? @samrose