### PR TITLE
refactor: convert Zipper internal representation from tuple to struct

### DIFF
--- a/lib/ex_integrate/pipeline.ex
+++ b/lib/ex_integrate/pipeline.ex
@@ -11,16 +11,17 @@ defmodule ExIntegrate.Core.Pipeline do
   @enforce_keys [:name, :steps]
   defstruct @enforce_keys ++ [failed?: false, completed_steps: []]
 
+  @type key :: String.t()
+
   @type t :: %__MODULE__{
           failed?: boolean,
-          name: String.t(),
-          steps: Zipper.t([Step.t()]),
-          completed_steps: [Step.t()]
+          name: key,
+          steps: Zipper.t(Step.t())
         }
 
-  @spec new(fields :: keyword | map) :: t
+  @spec new(Enum.t()) :: t
   def new(fields) do
-    fields = put_in(fields[:steps], Zipper.zip(fields[:steps]))
+    fields = update_in(fields[:steps], &Zipper.zip/1)
     struct!(__MODULE__, fields)
   end
 

--- a/lib/ex_integrate/zipper.ex
+++ b/lib/ex_integrate/zipper.ex
@@ -79,4 +79,8 @@ defmodule ExIntegrate.Core.Zipper do
       _ -> false
     end
   end
+
+  @spec zipper?(term) :: boolean
+  def zipper?({l, _, r}) when is_list(l) and is_list(r), do: true
+  def zipper?(_), do: false
 end

--- a/lib/ex_integrate/zipper.ex
+++ b/lib/ex_integrate/zipper.ex
@@ -29,23 +29,15 @@ defmodule ExIntegrate.Core.Zipper do
   end
 
   @spec zip(val) :: t(val) when val: list
-  def zip(list) when is_list(list) do
-    {[], nil, list}
-  end
+  def zip(list) when is_list(list), do: {[], nil, list}
 
   @spec node(t) :: term
-  def node({_l, current, _r}),
-    do: current
+  def node({_l, current, _r}), do: current
 
-  @spec right(t) :: t
-  def right({_, :end, []} = zipper),
-    do: raise(TraversalError, zipper)
-
-  def right({l, current, []}),
-    do: right({l, current, [:end]})
-
-  def right({[], nil, [head_r | tail_r]}),
-    do: {[], head_r, tail_r}
+  @spec right(t) :: t | no_return
+  def right({_, :end, []} = zipper), do: raise(TraversalError, zipper)
+  def right({l, current, []}), do: right({l, current, [:end]})
+  def right({[], nil, [head_r | tail_r]}), do: {[], head_r, tail_r}
 
   def right({l, old_current, [head_r | tail_r]}) do
     new_l = l ++ [old_current]
@@ -53,32 +45,24 @@ defmodule ExIntegrate.Core.Zipper do
   end
 
   @spec put_current(t, term) :: t
-  def put_current({l, _current_value, r}, new_value),
-    do: {l, new_value, r}
+  def put_current({l, _current_value, r}, new_value), do: {l, new_value, r}
 
   @spec rightmost(t) :: term
-  def rightmost({_l, _current, r}),
-    do: List.last(r)
+  def rightmost({_l, _current, r}), do: List.last(r)
 
-  def left_items({l, _current, _r}),
-    do: l
+  @spec left_items(t) :: list
+  def left_items({l, _current, _r}), do: l
 
-  def right_items({_l, _current, r}),
-    do: r
+  @spec right_items(t) :: list
+  def right_items({_l, _current, r}), do: r
 
-  def to_list({[], nil, r}),
-    do: r
-
-  def to_list({l, current, r}),
-    do: l ++ [current | r]
+  @spec to_list(t) :: list
+  def to_list({[], nil, r}), do: r
+  def to_list({l, current, r}), do: l ++ [current | r]
 
   @spec end?(t) :: boolean
-  def end?(zipper) do
-    case zipper do
-      {_, :end, []} -> true
-      _ -> false
-    end
-  end
+  def end?({_, :end, []}), do: true
+  def end?(_), do: false
 
   @spec zipper?(term) :: boolean
   def zipper?({l, _, r}) when is_list(l) and is_list(r), do: true

--- a/lib/ex_integrate/zipper.ex
+++ b/lib/ex_integrate/zipper.ex
@@ -15,17 +15,26 @@ defmodule ExIntegrate.Core.Zipper do
     * [ElixirForum post](https://elixirforum.com/t/elixir-needs-a-fifo-type/5701/24)
   """
 
-  defstruct l: [], current: nil, r: []
+  @initial_position -1
 
-  @end_token :end
+  @enforce_keys [:l, :r, :current, :size]
+  defstruct @enforce_keys ++ [position: @initial_position]
 
-  @type t :: %__MODULE__{
-          l: list,
-          current: term,
-          r: list
-        }
+  @opaque t :: %__MODULE__{
+            l: [term] | [],
+            current: term,
+            r: [term] | [],
+            size: non_neg_integer,
+            position: integer
+          }
 
-  @type t(val) :: %__MODULE__{r: val}
+  @opaque t(val) :: %__MODULE__{
+            r: [val] | [],
+            l: [val] | [],
+            current: val | nil,
+            size: non_neg_integer,
+            position: integer
+          }
 
   defmodule TraversalError do
     defexception [:message]
@@ -39,31 +48,96 @@ defmodule ExIntegrate.Core.Zipper do
 
   defguard is_zipper(term) when is_struct(term, __MODULE__)
 
-  @spec zip(val) :: t(val) when val: list
-  def zip(list) when is_list(list), do: %__MODULE__{r: list}
+  defguard is_at_start(zipper)
+           when zipper.l == [] and
+                  is_nil(zipper.current) and
+                  zipper.position == @initial_position
+
+  defguard is_at_end(zipper) when zipper.position == zipper.size
+
+  defguard is_out_of_bounds(zipper)
+           when is_zipper(zipper) and
+                  (zipper.position >= zipper.size or zipper.position < @initial_position)
+
+  @spec new(val) :: t(val) when val: list
+  def new(list) when is_list(list) do
+    struct!(__MODULE__,
+      l: [],
+      current: nil,
+      r: list,
+      size: length(list),
+      position: @initial_position
+    )
+  end
+
+  defdelegate zip(list), to: __MODULE__, as: :new
 
   @spec node(t) :: term
   def node(%__MODULE__{} = zipper), do: zipper.current
 
   @spec right(t) :: t | no_return
-  def right(%__MODULE__{current: @end_token, r: []} = zipper), do: raise(TraversalError, zipper)
-  def right(%__MODULE__{r: []} = zipper), do: right(%{zipper | r: [@end_token]})
+  def right(zipper) when is_out_of_bounds(zipper),
+    do: raise(TraversalError, zipper)
 
-  def right(%__MODULE__{l: [], current: nil, r: [head_r | tail_r]}),
-    do: %__MODULE__{current: head_r, r: tail_r}
+  def right(zipper) when is_at_start(zipper) do
+    zipper
+    |> Map.put(:current, hd(zipper.r))
+    |> Map.put(:r, tl(zipper.r))
+    |> Map.update(:position, nil, &(&1 + 1))
+  end
+
+  def right(%__MODULE__{r: []} = zipper) do
+    zipper
+    |> Map.put(:l, zipper.l ++ [zipper.current])
+    |> Map.update(:position, nil, &(&1 + 1))
+  end
 
   def right(%__MODULE__{} = zipper) do
-    l = zipper.l ++ [zipper.current]
-    [head_r | tail_r] = zipper.r
-    %__MODULE__{l: l, current: head_r, r: tail_r}
+    zipper
+    |> Map.put(:l, zipper.l ++ [zipper.current])
+    |> Map.put(:current, hd(zipper.r))
+    |> Map.put(:r, tl(zipper.r))
+    |> Map.update(:position, nil, &(&1 + 1))
+  end
+
+  @spec replace_at(t, non_neg_integer, term) :: t
+  def replace_at(%__MODULE__{size: size} = zipper, index, _)
+      when index >= size,
+      do: zipper
+
+  def replace_at(zipper, 0, new_value) when is_at_start(zipper) do
+    Map.update(zipper, :r, nil, fn r ->
+      List.replace_at(r, 0, new_value)
+    end)
+  end
+
+  def replace_at(%__MODULE__{position: position} = zipper, index, new_value)
+      when index == position do
+    Map.put(zipper, :current, new_value)
+  end
+
+  def replace_at(%__MODULE__{position: position} = zipper, index, new_value)
+      when index < position do
+    Map.update(zipper, :l, nil, fn l ->
+      List.replace_at(l, index, new_value)
+    end)
+  end
+
+  def replace_at(%__MODULE__{position: position} = zipper, index, new_value)
+      when index > position do
+    Map.update(zipper, :r, nil, fn r ->
+      r_index = index - position - 1
+      List.replace_at(r, r_index, new_value)
+    end)
   end
 
   @spec put_current(t, term) :: t
   def put_current(%__MODULE__{} = zipper, new_value),
-    do: %{zipper | current: new_value}
+    do: replace_at(zipper, zipper.position, new_value)
 
   @spec rightmost(t) :: term
-  def rightmost(%__MODULE__{} = zipper), do: zipper |> right_items() |> List.last()
+  def rightmost(%__MODULE__{} = zipper),
+    do: zipper |> right_items() |> List.last()
 
   @spec left_items(t) :: list
   def left_items(%__MODULE__{} = zipper), do: zipper.l
@@ -72,11 +146,17 @@ defmodule ExIntegrate.Core.Zipper do
   def right_items(%__MODULE__{} = zipper), do: zipper.r
 
   @spec to_list(t) :: list
-  def to_list(%__MODULE__{l: [], current: nil, r: r}), do: r
-  def to_list(%__MODULE__{} = zipper), do: Enum.concat([zipper.l, zipper.r, [zipper.current]])
+  def to_list(zipper) when is_at_start(zipper), do: zipper.r
+
+  def to_list(zipper) when is_at_start(zipper) or is_at_end(zipper),
+    do: zipper.l ++ zipper.r
+
+  def to_list(%__MODULE__{} = zipper),
+    do: zipper.l ++ [zipper.current] ++ zipper.r
 
   @spec end?(t) :: boolean
-  def end?(%__MODULE__{} = zipper), do: zipper.current == @end_token
+  def end?(zipper) when is_at_end(zipper), do: true
+  def end?(_), do: false
 
   @spec zipper?(term) :: boolean
   def zipper?(zipper) when is_zipper(zipper), do: true

--- a/lib/ex_integrate/zipper.ex
+++ b/lib/ex_integrate/zipper.ex
@@ -59,7 +59,7 @@ defmodule ExIntegrate.Core.Zipper do
            when is_zipper(zipper) and
                   (zipper.position >= zipper.size or zipper.position < @initial_position)
 
-  @spec new(val) :: t(val) when val: list
+  @spec new([val]) :: t(val) when val: term
   def new(list) when is_list(list) do
     struct!(__MODULE__,
       l: [],

--- a/test/ex_integrate/zipper_test.exs
+++ b/test/ex_integrate/zipper_test.exs
@@ -69,4 +69,16 @@ defmodule ExIntegrate.Core.ZipperTest do
 
     assert Z.end?(zipper_at_end)
   end
+
+  describe "checking if the input is a zipper" do
+    test "returns true for zippers" do
+      zipper = Z.zip([1, 2, 3])
+      assert Z.zipper?(zipper)
+    end
+
+    test "returns false for non-zippers" do
+      non_zipper = Enum.random([["not", "a", "zipper"], Enum.random(0..1000), :foobar])
+      refute Z.zipper?(non_zipper)
+    end
+  end
 end

--- a/test/ex_integrate/zipper_test.exs
+++ b/test/ex_integrate/zipper_test.exs
@@ -3,38 +3,93 @@ defmodule ExIntegrate.Core.ZipperTest do
 
   alias ExIntegrate.Core.Zipper, as: Z
 
-  test "initially, current item is nil" do
-    zipper = Z.zip([1, 2, :foo])
-    assert is_nil(Z.node(zipper))
+  describe "moving to the right" do
+    test "initially, current item is nil" do
+      zipper = Z.zip([1, 2, :foo])
+      assert is_nil(Z.node(zipper))
+    end
+
+    test "when there are still items to the right, moves to the right" do
+      zipper = [1, 2] |> Z.zip() |> Z.right()
+      assert Z.node(zipper) == 1
+    end
+
+    test "end position is one past the rightmost item" do
+      zipper = [1, 2] |> Z.zip() |> Z.right() |> Z.right() |> Z.right()
+      assert Z.end?(zipper)
+    end
+
+    test "raises when trying to move past the end" do
+      zipper = [1, 2] |> Z.zip()
+
+      assert_raise Z.TraversalError, fn ->
+        zipper |> Z.right() |> Z.right() |> Z.right() |> Z.right()
+      end
+    end
   end
 
-  describe "modifying current item" do
+  describe "updating an item" do
+    setup :generate_random_item
+
+    defp generate_random_item(_) do
+      item = Enum.random([:bar, [[42], "foo"], %{baz: :bat}])
+      [item: item]
+    end
+
+    test "returns updated zipper when zipper is at beginning", %{item: item} do
+      zipper =
+        [1, 2, 42]
+        |> Z.zip()
+        |> Z.replace_at(0, item)
+
+      assert Z.to_list(zipper) == [item, 2, 42]
+    end
+
+    test "returns updated zipper when item is in focus", %{item: item} do
+      zipper =
+        [1, 2, 42]
+        |> Z.zip()
+        |> Z.right()
+        |> Z.replace_at(0, item)
+
+      assert Z.to_list(zipper) == [item, 2, 42]
+    end
+
+    test "returns updated zipper when item is left of focus", %{item: item} do
+      zipper =
+        [1, 2, 42]
+        |> Z.zip()
+        |> Z.right()
+        |> Z.right()
+        |> Z.replace_at(0, item)
+
+      assert Z.to_list(zipper) == [item, 2, 42]
+    end
+
+    test "returns updated zipper when item is right of focus", %{item: item} do
+      zipper =
+        [1, 2, 42]
+        |> Z.zip()
+        |> Z.right()
+        |> Z.right()
+        |> Z.replace_at(2, item)
+
+      assert Z.to_list(zipper) == [1, 2, item]
+    end
+
+    test "returns original zipper when index is out of bounds" do
+      zipper = [1, 2, 42] |> Z.zip()
+      assert zipper == Z.replace_at(zipper, 100, :not_updated)
+    end
+  end
+
+  describe "updating current item" do
     test "on success, modifies the item" do
       zipper = [1, 2, 42] |> Z.zip() |> Z.right()
       new_item = Enum.random([:bar, [[42], "foo"], %{baz: :bat}])
       updated_zipper = Z.put_current(zipper, new_item)
 
       assert Z.node(updated_zipper) == new_item
-    end
-  end
-
-  describe "moving to the right" do
-    test "when there are items to the right, moves to the right" do
-      zipper = [1, 2] |> Z.zip() |> Z.right()
-      assert Z.node(zipper) == 1
-    end
-
-    test "when at the end, adds an 'end' token" do
-      zipper = [42, :foo, ["bar"]] |> Z.zip() |> Z.right() |> Z.right() |> Z.right() |> Z.right()
-      assert Z.node(zipper) == :end
-    end
-
-    test "raises when trying to move past the 'end' token" do
-      zipper = [1] |> Z.zip()
-
-      assert_raise Z.TraversalError, fn ->
-        zipper |> Z.right() |> Z.right() |> Z.right()
-      end
     end
   end
 
@@ -55,7 +110,11 @@ defmodule ExIntegrate.Core.ZipperTest do
 
   test "converts to list" do
     original_list = [1..2, {"something", :foo, []}, {{:bar}}]
+
     zipper = Z.zip(original_list)
+    assert Z.to_list(zipper) == original_list
+
+    zipper = zipper |> Z.right() |> Z.right() |> Z.right()
     assert Z.to_list(zipper) == original_list
   end
 


### PR DESCRIPTION
Closes #32.

Also adds `Zipper.replace_at/3`, which allows replacing zipper items at the specified index (same external behavior as `List.replace_at/3`.