### PR TITLE
doc: add moduledocs to all public modules

### DIFF
--- a/lib/ex_integrate/application.ex
+++ b/lib/ex_integrate/application.ex
@@ -10,7 +10,7 @@ defmodule ExIntegrate.Application do
     children = [
       # Starts a worker by calling: ExIntegrate.Worker.start_link(arg)
       # {ExIntegrate.Worker, arg}
-      {Task.Supervisor, name: ExIntegrate.TaskSupervisor},
+      {Task.Supervisor, name: ExIntegrate.TaskSupervisor}
     ]
 
     # See https://hexdocs.pm/elixir/Supervisor.html

--- a/lib/ex_integrate/config_parser.ex
+++ b/lib/ex_integrate/config_parser.ex
@@ -1,4 +1,7 @@
 defmodule ExIntegrate.Boundary.ConfigParser do
+  @moduledoc """
+  Validates and parses the user config file.
+  """
   def import_json(filename) when is_binary(filename) do
     filename
     |> File.read!()

--- a/lib/ex_integrate/pipeline.ex
+++ b/lib/ex_integrate/pipeline.ex
@@ -1,4 +1,8 @@
 defmodule ExIntegrate.Core.Pipeline do
+  @moduledoc """
+  A collection of Steps to be run sequentially.
+  """
+
   alias ExIntegrate.Core.Step
   alias ExIntegrate.Core.Zipper
 

--- a/lib/ex_integrate/run.ex
+++ b/lib/ex_integrate/run.ex
@@ -1,4 +1,17 @@
 defmodule ExIntegrate.Core.Run do
+  @moduledoc """
+  A `Run` represents an entire CI orchestrated workflow, from start to finish.
+
+  A Run consists of many `Pipeline`s, which it runs in parallel except when they
+  depend on each other. Internally, the pipelines are stored in a directed
+  acyclic graph (DAG), and this graph is traversed from start to finish as
+  pipelines are launched and completed.
+
+  The `%Run{}` struct stores
+    * the complete specification for the run's execution,
+    * the results of the run, including the output of all `Step`s, and
+    * metadata.
+  """
   alias ExIntegrate.Core.Pipeline
   alias ExIntegrate.Core.Step
 
@@ -62,9 +75,9 @@ defmodule ExIntegrate.Core.Run do
   end
 
   @doc """
-  Updates the given pipeline in the run's collection.
+    Updates the given pipeline in the run's collection.
 
-  Returns the run with updated pipeline.
+    Returns the run with updated pipeline.
   """
   @spec put_pipeline(t(), Pipeline.t() | pipeline_key, Pipeline.t()) :: t()
   def put_pipeline(%__MODULE__{} = run, %Pipeline{} = old_pipeline, %Pipeline{} = new_pipeline) do

--- a/lib/ex_integrate/step.ex
+++ b/lib/ex_integrate/step.ex
@@ -1,18 +1,18 @@
 defmodule ExIntegrate.Core.Step do
   @moduledoc """
-  Represents a step in the CI pipeline. 
+  Represents a single unit of work in the CI pipeline. Steps run sequentially
+  inside Pipelines.
+
+  A step stores data specifying what is to be executed as well as data about the
+  result of command execution. It has a unique `name`, a `command`, and
+  multiple `args`.
+
+  Note that the `name` must be unique, as it is used internally as a unique key
+  to identify steps.
   """
 
   @enforce_keys [:name, :command, :args]
-
-  defstruct [
-    :args,
-    :command,
-    :name,
-    err: nil,
-    out: nil,
-    status_code: nil
-  ]
+  defstruct @enforce_keys ++ [:err, :out, :status_code]
 
   @type t :: %__MODULE__{
           args: [String.t()],

--- a/lib/ex_integrate/step_runner.ex
+++ b/lib/ex_integrate/step_runner.ex
@@ -1,4 +1,13 @@
 defmodule ExIntegrate.Boundary.StepRunner do
+  @moduledoc """
+  Responsible for running `Step`s, the primary units of CI work. See `Step` docs
+  for more information.
+
+  Note that for now, running a step always consists of determing its system
+  executable and making an external system call via `Rambo`. In the future,
+  for testing purposes, it may be desirable to add a mock implementation that
+  avoids the external system call. 
+  """
   alias ExIntegrate.Core.Step
 
   @spec run_step(Step.t()) :: {:ok, Step.t()} | {:error, Step.t()}


### PR DESCRIPTION
The result is that `mix credo` now passes, making it ready for CI.

(Also mix format application.ex)